### PR TITLE
Add link icon

### DIFF
--- a/components/sections/link-icon.tsx
+++ b/components/sections/link-icon.tsx
@@ -1,0 +1,121 @@
+import * as Si from '@icons-pack/react-simple-icons';
+import { Link } from 'lucide-react';
+
+interface Props {
+  url: string;
+  size?: string | number;
+}
+
+export default function LinkIcon({ url, size }: Props) {
+  const matchedKey = Object.keys(iconMap).find(key =>
+    iconMap[key].urls.some(link => url.includes(link))
+  );
+
+  const Icon = matchedKey ? iconMap[matchedKey].Icon : Link;
+  
+  return <Icon size={size} />;
+}
+
+interface IconMapEntry {
+  urls: string[]; 
+  Icon: Si.IconType;
+}
+
+const iconMap: Record<string, IconMapEntry> = {
+  appleMusic: {
+    urls: ['music.apple.com'],
+    Icon: Si.SiApplemusic,
+  },
+  bitbucket: {
+    urls: ['bitbucket.org'],
+    Icon: Si.SiBitbucket,
+  },
+  cashApp: {
+    urls: ['cash.app'],
+    Icon: Si.SiCashapp,
+  },
+  discord: {
+    urls: ['discord.gg'],
+    Icon: Si.SiDiscord,
+  },
+  facebook: {
+    urls: ['facebook.com', 'fb.me', 'fb.watch'],
+    Icon: Si.SiFacebook,
+  },
+  github: {
+    urls: ['github.com', 'gh.io'],
+    Icon: Si.SiGithub,
+  },
+  gitlab: {
+    urls: ['gitlab.com'],
+    Icon: Si.SiGitlab,
+  },
+  instagram: {
+    urls: ['instagram.com', 'instagr.am'],
+    Icon: Si.SiInstagram,
+  },
+  linkedin: {
+    urls: ['linkedin.com', 'lnkd.in'],
+    Icon: Si.SiLinkedin,
+  },
+  medium: {
+    urls: ['medium.com'],
+    Icon: Si.SiMedium,
+  },
+  paypal: {
+    urls: ['paypal.com', 'paypal.me'],
+    Icon: Si.SiPaypal,
+  },
+  pinterest: {
+    urls: ['pinterest.com', 'pin.it'],
+    Icon: Si.SiPinterest,
+  },
+  reddit: {
+    urls: ['reddit.com', 'redd.it'],
+    Icon: Si.SiReddit,
+  },
+  spotify: {
+    urls: ['spotify.com'],
+    Icon: Si.SiSpotify,
+  },
+  snapchat: {
+    urls: ['snapchat.com'],
+    Icon: Si.SiSnapchat,
+  },
+  telegram: {
+    urls: ['t.me'],
+    Icon: Si.SiTelegram,
+  },
+  tiktok: {
+    urls: ['tiktok.com'],
+    Icon: Si.SiTiktok,
+  },
+  twitter: {
+    urls: ['twitter.com', 'x.com', 't.co'],
+    Icon: Si.SiX,
+  },
+  twitch: {
+    urls: ['twitch.tv'],
+    Icon: Si.SiTwitch,
+  },
+  venmo: {
+    urls: ['venmo.com'],
+    Icon: Si.SiVenmo,
+  },
+  whatsapp: {
+    urls: ['wa.me'],
+    Icon: Si.SiWhatsapp,
+  },
+  wordpress: {
+    urls: ['wordpress.com'],
+    Icon: Si.SiWordpress,
+  },
+  youtube: {
+    urls: ['youtube.com', 'youtu.be'],
+    Icon: Si.SiYoutube,
+  },
+  zoom: {
+    urls: ['zoom.us'],
+    Icon: Si.SiZoom,
+  },
+};

--- a/components/sections/links.tsx
+++ b/components/sections/links.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ArrowUpRight, Plus, Settings, User } from "lucide-react";
 import { Icons } from "@/lib/types/icons";
 import { getCategories } from "@/lib/project/get-categories";
+import LinkIcon from "./link-icon";
 
 interface LinksSectionProps {
 	links: LinkType[] | [] | null;
@@ -33,8 +34,6 @@ export function LinksSection({ links }: LinksSectionProps) {
 								</h2>
 								<div className="flex flex-col gap-2">
 									{categoryLinks.map((link, idx) => {
-										const IconComponent = link.icon ? Icons[link.icon.icon] : null;
-
 										return (
 											<Link
 												key={idx}
@@ -47,19 +46,10 @@ export function LinksSection({ links }: LinksSectionProps) {
 														: "bg-card hover:bg-muted"
 												} ${link.description ? "" : "items-center"}`}
 											>
-												{IconComponent && (
-													<div
-														className={`size-10 flex items-center justify-center ${
-															link.icon?.featured
-																? "rounded-full shadow bg-primary text-primary-foreground"
-																: idx === 0
-																? "text-primary-foreground"
-																: "text-primary"
-														}`}
-													>
-														<IconComponent size={24} />
-													</div>
-												)}
+												<div className='flex items-center justify-center'>
+													<LinkIcon url={link.url} size="36" />
+												</div>
+
 												<div className="space-y-1 pr-6">
 													<h3 className={`text-lg font-semibold ${idx === 0 ? "text-primary-foreground" : "text-foreground"}`}>
 														{link.title}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@icons-pack/react-simple-icons": "^10.0.0",
         "@octokit/core": "^6.1.2",
         "@radix-ui/react-checkbox": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.1",
@@ -194,6 +195,15 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
+    },
+    "node_modules/@icons-pack/react-simple-icons": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-10.0.0.tgz",
+      "integrity": "sha512-oU0PVDx9sbNQjRxJN555dsHbRApYN+aBq/O9+wo3JgNkEfvBMgAEtsSGtXWWXQsLAxJcYiFOCzBWege/Xj/JFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@icons-pack/react-simple-icons": "^10.0.0",
     "@octokit/core": "^6.1.2",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.1",


### PR DESCRIPTION
Adding site icon from Simple Icons (Lucide's brand icons are deprecated) within each link. The icon is detected automatically based on the URL provided and will fall back to Lucide's link icon if a matching icon is not found.

[Live preview](https://gmonlink.osborn.app/zekeosborn) #12 